### PR TITLE
error event now properly sets .playing property to 'false'

### DIFF
--- a/src/audio5.js
+++ b/src/audio5.js
@@ -647,6 +647,7 @@
      * @param e error event
      */
     onError: function (e) {
+      this.trigger('pause');
       this.trigger('error', e);
     },
     /**


### PR DESCRIPTION
**Issue:**  For achieving playlist like behavior of HTML5 audio, one usually calls some sort of `playNextSong()` function in response to the **'ended'** event.  In the event a song fails to load, one should also call this function.  While this was working fine for desktop browsers, it came to my attention that on mobile safari audio did not continue playing, although it did appear to load. Subsequent attempts to play or pause the song did nothing.

Upon inspection, attempting to click play did nothing because the Audio5js object was in a **'playing: true'** state and so pause was called, which also had no effect for reasons I cannot recall at this time. Oh well.
Regardless, the solution was to trigger a **'pause'** event when an error arose.  This correctly set the state of the Audio5js player to **'playing: false'** and auto-play continued flawlessly.  As to why this only caused issues in a mobile browser, I'm sure I do not know.