### PR TITLE
Attempting to load a new url properly sets .playing to 'false'

### DIFF
--- a/src/audio5.js
+++ b/src/audio5.js
@@ -686,6 +686,7 @@
      */
     load: function (url) {
       this.reset();
+      this.trigger('pause');
       //this.destroyAudio();
       if(this.audio === undefined){
         this.createAudio();


### PR DESCRIPTION
**Issue:** When attempting to load a new song before the current audio had finished playing, the HTML5 player was getting stuck in a state of playing with no actual audio output.  Triggering **'pause'** from within the HTML5 `load` function solves this issue.