### PR TITLE
fix IE9 bug in win server 2008

### DIFF
--- a/src/audio5.js
+++ b/src/audio5.js
@@ -198,7 +198,11 @@
         if (mime_type === 'mp3' && navigator.userAgent.match(/Android/i) && navigator.userAgent.match(/Firefox/i)) {
           return true;
         }
-        return !!a.canPlayType && a.canPlayType(mime_str) !== '';
+        try {
+          return !!a.canPlayType && a.canPlayType(mime_str) !== '';
+        } catch (e) {
+          return false;
+        }
       }
       return false;
     },


### PR DESCRIPTION
call canPlayType() of audio element in IE9 on win server 2008 will throw error

![not-implement](https://cloud.githubusercontent.com/assets/4136679/9265627/9eba1348-4268-11e5-826a-31be7a407098.png)

see: https://groups.google.com/forum/#!topic/jplayer/knAxCsT2IKk