### PR TITLE
Return promise from .play()

### DIFF
--- a/audio5.js
+++ b/audio5.js
@@ -723,8 +723,9 @@
      */
     play: function () {
       if(this.audio) {
-        this.audio.play();
+        var playPromise = this.audio.play();
         this.audio.playbackRate = this._rate;
+        return playPromise;
       }
     },
     /**
@@ -941,7 +942,7 @@
      */
     play: function () {
       if(!this.playing){
-        this.audio.play();
+        return this.audio.play();
       }
     },
     /**


### PR DESCRIPTION
On mobile Chrome and Safari autoplay is no longer possible. A user interaction for playing audio is now mandatory. To check if autoplay works or if we should show a button (to click play), we need the check the promise returned by .play().

Example:
```javascript
function initAudio () {
        var audio5js = new Audio5js({
            ready: function () {
                this.load("beep.mp3");
                var promisePlay = this.play();
                if (promisePlay !== undefined) {
                    promisePlay.catch(function () {
                        var btn = document.getElementById("play-pause");
                        btn.addEventListener('click', playPause.bind(this), false);
                    }.bind(this));
                }
            }
        });
    }
initAudio();
```

See also the new policies:
https://webkit.org/blog/7734/auto-play-policy-changes-for-macos/
https://developers.google.com/web/updates/2017/09/autoplay-policy-changes#best-practises